### PR TITLE
Avoid Undefined Behavior of casting negative double -> unsigned int

### DIFF
--- a/src/bit-ops.c
+++ b/src/bit-ops.c
@@ -25,7 +25,7 @@ SEXP bitFlip(SEXP a, SEXP bitWidth )
 	if ( !R_FINITE(xa[i]) || logb(xa[i])>31 )
 	    xaflip[i]=NA_REAL ;
 	else {
-		unsigned int tmp = _2_UINT_(xa[i);
+		unsigned int tmp = _2_UINT_(xa[i]);
 	    xaflip[i]=(double) ( ~tmp & mask ) ;
 	}
     }


### PR DESCRIPTION
A change to LLVM triggered a UB crash in {bitops} examples, e.g.

```
  1. bitAnd.Rd
    Output prior to failure:
      > ### Name: bitAnd
      > ### Title: Bitwise And, Or and Xor Operations
      > ### Aliases: bitAnd bitOr bitXor %&% %|% %^%
      > ### Keywords: arith utilities
      > 
      > ### ** Examples
      > 
      > bitAnd(15,7) == 7 ;  identical(15 %&% 7, bitAnd(15, 7))
      [1] TRUE
      [1] TRUE
      > bitOr(15,7) == 15 ;  identical(15 %|% 7, bitOr (15, 7))
      [1] TRUE
      [1] TRUE
      > bitXor(15,7) == 8 ;  identical(15 %^% 7, bitXor(15,7))
      [1] TRUE
      [1] TRUE
      > bitOr(-1,0) == 4294967295 ; identical(-1 %|% 0, bitOr(-1,0))
      
       *** caught illegal operation ***
      address 0x7f19086c9825, cause 'illegal operand'
      
      Traceback:
       1: bitOr(-1, 0)
      An irrecoverable exception occurred. R is aborting now ...
```

Reported further debugging under ASAN:

```
WARNING: UndefinedBehaviorSanitizer: float-cast-overflow bitops/src/bit-ops.c:88:5
WARNING: UndefinedBehaviorSanitizer: float-cast-overflow bitops/src/bit-ops.c:29:6
WARNING: UndefinedBehaviorSanitizer: float-cast-overflow bitops/src/bit-ops.c:146:5
```

Bisected LLVM change:

https://github.com/llvm/llvm-project/commit/3de4d32a7228519312a844bcd48a34124b1a718b

The problem is that the compiler might evaluate the RHS of the ternary operator in:

```c
(unsigned int)( (X) < 0 ? Y : (X))
```

And `(unsigned int)(<double>)` is undefined:

https://stackoverflow.com/a/10541255/3576984

The supported way to do this cast is through `long long`:

https://stackoverflow.com/a/21769421/3576984
